### PR TITLE
Update to use Duration & std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ keywords = ["schedule_recv", "timer"]
 
 [dependencies]
 lazy_static = "*"
-time = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,9 @@
 
 
 #[macro_use] extern crate lazy_static;
-extern crate time;
 
 mod scheduler;
 
 #[cfg(test)] mod test;
 
-pub use scheduler::{oneshot_ms, periodic_ms};
+pub use scheduler::{oneshot_ms, periodic_ms, oneshot, periodic, periodic_after};

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -4,19 +4,13 @@ use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::sync::{Arc};
 use std::sync::mpsc::{Sender, Receiver, channel};
-use std::cmp::{Ordering, min, max};
-
-use time::{SteadyTime, Duration};
+use std::cmp::{Ordering};
+use std::time::{Instant, Duration};
 
 struct ScheduledEvent {
-    when: SteadyTime,
+    when: Instant,
     completion_sink: Sender<()>,
-    period: Option<u32>,
-}
-impl Ord for ScheduledEvent {
-    fn cmp(&self, other: &ScheduledEvent) -> Ordering {
-        other.when.cmp(&self.when)
-    }
+    period: Option<Duration>,
 }
 impl PartialEq for ScheduledEvent {
     fn eq(&self, other: &ScheduledEvent) -> bool {
@@ -27,31 +21,30 @@ impl PartialEq for ScheduledEvent {
     }
 }
 impl Eq for ScheduledEvent {}
+impl Ord for ScheduledEvent {
+    fn cmp(&self, other: &ScheduledEvent) -> Ordering {
+        other.when.cmp(&self.when)
+    }
+}
 impl PartialOrd for ScheduledEvent {
     fn partial_cmp(&self, other: &ScheduledEvent) -> Option<Ordering> {
         other.when.partial_cmp(&self.when)
     }
 }
 
-struct SchedulingRequest {
-    duration: u32,
-    periodic: bool,
-    completion_sink: Sender<()>,
-}
-
 struct SchedulingInterface {
     trigger: Arc<Condvar>,
-    adder: Sender<SchedulingRequest>,
+    adder: Sender<ScheduledEvent>,
 }
 
 struct ScheduleWorker {
     trigger: Arc<Condvar>,
-    request_source: Receiver<SchedulingRequest>,
+    request_source: Receiver<ScheduledEvent>,
     schedule: BinaryHeap<ScheduledEvent>,
 }
 
 impl ScheduleWorker {
-    fn new(trigger: Arc<Condvar>, request_source: Receiver<SchedulingRequest>) -> ScheduleWorker {
+    fn new(trigger: Arc<Condvar>, request_source: Receiver<ScheduledEvent>) -> ScheduleWorker {
         ScheduleWorker{
             trigger: trigger,
             request_source: request_source,
@@ -61,17 +54,13 @@ impl ScheduleWorker {
 
     fn drain_request_queue(&mut self) {
         while let Ok(request) = self.request_source.try_recv() {
-            self.schedule.push(ScheduledEvent{
-                when: SteadyTime::now() + Duration::milliseconds(request.duration as i64),
-                period: if request.periodic { Some(request.duration) } else { None },
-                completion_sink: request.completion_sink
-            });
+            self.schedule.push(request);
         }
     }
 
     fn has_event_now(&self) -> bool {
         if let Some(evt) = self.schedule.peek() {
-            evt.when < SteadyTime::now()
+            evt.when <= Instant::now()
         } else {
             false
         }
@@ -81,9 +70,9 @@ impl ScheduleWorker {
         if let Some(evt) = self.schedule.pop() {
             match evt.completion_sink.send( () ) {
                 Ok( () ) => {
-                    if let Some(period) = evt.period.clone() {
+                    if let Some(period) = evt.period {
                         self.schedule.push(ScheduledEvent{
-                            when: evt.when + Duration::milliseconds(period as i64),
+                            when: evt.when + period,
                             period: evt.period,
                             completion_sink: evt.completion_sink,
                         });
@@ -96,12 +85,15 @@ impl ScheduleWorker {
         }
     }
 
-    fn ms_until_next_event(&self) -> u32 {
-        if let Some(evt) = self.schedule.peek() {
-            max(0, min((evt.when - SteadyTime::now()).num_milliseconds(), 100000))  as u32
-        } else {
-            100000
-        }
+    fn dur_until_next_event(&self) -> Option<Duration> {
+        self.schedule.peek().map(|evt| {
+            let now = Instant::now();
+            if evt.when <= now {
+                Duration::from_secs(0)
+            } else {
+                evt.when.duration_since(now)
+            }
+        })
     }
 
     fn run(&mut self) {
@@ -112,25 +104,25 @@ impl ScheduleWorker {
             self.drain_request_queue();
 
             // Fire off as many events as we are supposed to.
-            loop {
-                if self.has_event_now() {
-                    self.fire_event();
-                } else {
-                    break;
-                }
+            while self.has_event_now() {
+                self.fire_event();
             }
 
-            let wait_millis = self.ms_until_next_event();
+            let wait_duration = self.dur_until_next_event();
 
             // unwrap() is safe because the mutex will not be poisoned,
             // since we have not shared it with another thread.
-            g = self.trigger.wait_timeout_ms(g, wait_millis).unwrap().0;
+            g = if let Some(wait_duration) = wait_duration {
+                self.trigger.wait_timeout(g, wait_duration).unwrap().0
+            } else {
+                self.trigger.wait(g).unwrap()
+            };
         }
     }
 }
 
 lazy_static! {
-    static ref SCHEDULER_INTERFACE  : Mutex<SchedulingInterface> = {
+    static ref SCHEDULER_INTERFACE : Mutex<SchedulingInterface> = {
         let (sender, receiver) = channel();
         let trigger = Arc::new(Condvar::new());
         let trigger2 = trigger.clone();
@@ -147,14 +139,14 @@ lazy_static! {
     };
 }
 
-fn add_request(duration_ms: u32, periodic: bool) -> Receiver<()> {
+fn add_request(duration: Duration, period: Option<Duration>) -> Receiver<()> {
     let (sender, receiver) = channel();
 
     let interface = SCHEDULER_INTERFACE.lock().ok().expect("Failed to acquire the global scheduling worker");
-    interface.adder.send(SchedulingRequest{
-        duration:duration_ms,
-        completion_sink:sender,
-        periodic: periodic
+    interface.adder.send(ScheduledEvent {
+        when: Instant::now() + duration,
+        completion_sink: sender,
+        period: period
     }).ok().expect("Failed to send a request to the global scheduling worker");
 
     interface.trigger.notify_one();
@@ -165,11 +157,27 @@ fn add_request(duration_ms: u32, periodic: bool) -> Receiver<()> {
 /// Starts a timer which after `ms` milliseconds will issue a **single** `.send(())` on the other side of the
 /// returned `Reciever<()>`.
 pub fn oneshot_ms(ms: u32) -> Receiver<()> {
-    add_request(ms, false)
+    oneshot(Duration::from_millis(ms as u64))
 }
 
 /// Starts a timer which, **every** `ms` milliseconds, will issue `.send(())` on the other side of the
 /// returned `Reciever<()>`.
 pub fn periodic_ms(ms: u32) -> Receiver<()> {
-    add_request(ms, true)
+    periodic(Duration::from_millis(ms as u64))
+}
+
+/// Starts a timer which after `duration` will issue a **single** `.send(())` on the other side of the
+/// returned `Receiver<()>`.
+pub fn oneshot(duration: Duration) -> Receiver<()> {
+    add_request(duration, None)
+}
+
+/// Starts a timer which, every `duration`, will issue a **single** `.send(())` on the other side of the
+/// returned `Receiver<()>`.
+pub fn periodic(duration: Duration) -> Receiver<()> {
+    add_request(duration, Some(duration))
+}
+
+pub fn periodic_after(period: Duration, start: Duration) -> Receiver<()> {
+    add_request(start, Some(period))
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,22 +1,25 @@
 
+use std::time::{Instant, Duration};
+
 use scheduler::{oneshot_ms, periodic_ms};
-use time::SteadyTime;
 
 struct ElapsedChecker {
-    start: SteadyTime
+    start: Instant
 }
 
 impl ElapsedChecker {
     fn new() -> ElapsedChecker {
         ElapsedChecker {
-            start: SteadyTime::now()
+            start: Instant::now()
         }
     }
 
-    fn check(&self, expected_ms: i64) {
-        let actual_elapsed_ms = (SteadyTime::now() - self.start).num_milliseconds();
-        assert!(actual_elapsed_ms-100 < expected_ms, "Elapsed too late: {}ms instead of {}ms", actual_elapsed_ms, expected_ms);
-        assert!(actual_elapsed_ms+100 > expected_ms, "Elapsed too soon: {}ms instead of {}ms", actual_elapsed_ms, expected_ms);
+    fn check(&self, expected_ms: u64) {
+        let actual_elapsed = self.start.elapsed();
+        let expected = Duration::from_millis(expected_ms);
+        assert!(actual_elapsed > Duration::from_millis(100), "Less than 100ms elapsed");
+        assert!(actual_elapsed-Duration::from_millis(100) < expected, "Elapsed too late: {:?} instead of {:?}", actual_elapsed, expected);
+        assert!(actual_elapsed+Duration::from_millis(100) > expected, "Elapsed too soon: {:?} instead of {:?}", actual_elapsed, expected);
     }
 }
 
@@ -69,7 +72,7 @@ fn simple_periodic() {
     let checker = ElapsedChecker::new();
     let p = periodic_ms(200);
 
-    for i in (1..10) {
+    for i in 1..10 {
         p.recv().unwrap();
         checker.check(i*200);
     }


### PR DESCRIPTION
This drops the use of deprecated methods & the deprecated time crate
Additionally SchedulingRequest & SheduledEvent are combined
3 new methods are introduced: oneshot, periodic, periodic_after
The first 2 are duration taking equivalents to *_ms
The last allows an event to start at a different duration than its period
