### PR TITLE
Add examples from the README into the 'examples' directory

### DIFF
--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -1,0 +1,10 @@
+extern crate schedule_recv;
+
+use schedule_recv::oneshot_ms;
+
+fn main() {
+    let timer = oneshot_ms(1500);
+    timer.recv().unwrap();
+
+    println!("1.5 seconds have elapsed.");
+}

--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -1,0 +1,19 @@
+extern crate schedule_recv;
+
+use schedule_recv::periodic_ms;
+use std::time::Duration;
+use std::thread;
+
+fn main() {
+    let tick = periodic_ms(2000);
+    thread::sleep(Duration::from_millis(1000));
+    let tock = periodic_ms(2000);
+
+    loop {
+        tick.recv().unwrap();
+        println!("Tick");
+
+        tock.recv().unwrap();
+        println!("Tock");
+    }
+}


### PR DESCRIPTION
This is a more cannonical place for examples, and it also allows users
to run them using `cargo run --example oneshot`.